### PR TITLE
hammerheadcaf: Do not ship PowerControl widget

### DIFF
--- a/overlay/packages/apps/Settings/res/values/bools.xml
+++ b/overlay/packages/apps/Settings/res/values/bools.xml
@@ -19,5 +19,5 @@
     <bool name="config_show_mobile_plan">false</bool>
 
     <!-- PowerControl is deprecated, but it was shipped with this device -->
-    <bool name="has_powercontrol_widget">true</bool>
+    <bool name="has_powercontrol_widget">false</bool>
 </resources>


### PR DESCRIPTION
PowerControl widget causes a force close after boot.

Change-Id: I5f738b62f2712c9699613c9ff0a81949894e9ce4